### PR TITLE
Pad vote history, delete sysvars

### DIFF
--- a/pkg/ndau/chain_builders.go
+++ b/pkg/ndau/chain_builders.go
@@ -400,6 +400,18 @@ func BuildVMForNodeGoodness(
 		}
 	}
 
+	// Pad the node's voting history with good votes if it's too small
+
+	if len(votingHistory) < metast.HistorySize {
+		var goodRoundStats metast.NodeRoundStats
+		goodRoundStats.Power = 1
+		goodRoundStats.Voted = true
+		goodRoundStats.AgainstConsensus = false
+		for n := len(votingHistory); n < metast.HistorySize; n++ {
+			votingHistory = append(votingHistory, goodRoundStats)
+		}
+	}
+
 	votingHistoryV, err := chain.ToValue(votingHistory)
 	if err != nil {
 		return nil, errors.Wrap(err, "votingHistory")


### PR DESCRIPTION
These two changes are independent of each other. Each is a standalone set of changes to just one file. (1) If a node's voting history is shorter than expected (20 blocks), pad it with good voting records when building the VM for node goodness. (2) Setting a sysvar to an empty string deletes it (and silently succeeds if the sysvar does not exist).