### PR TITLE
Pad vote history, delete sysvars

### DIFF
--- a/pkg/ndau/chain_builders.go
+++ b/pkg/ndau/chain_builders.go
@@ -400,6 +400,18 @@ func BuildVMForNodeGoodness(
 		}
 	}
 
+	// Pad the node's voting history with good votes if it's too small
+
+	if len(votingHistory) < metast.HistorySize {
+		var goodRoundStats metast.NodeRoundStats
+		goodRoundStats.Power = 1
+		goodRoundStats.Voted = true
+		goodRoundStats.AgainstConsensus = false
+		for n := len(votingHistory); n < metast.HistorySize; n++ {
+			votingHistory = append(votingHistory, goodRoundStats)
+		}
+	}
+
 	votingHistoryV, err := chain.ToValue(votingHistory)
 	if err != nil {
 		return nil, errors.Wrap(err, "votingHistory")

--- a/pkg/ndau/tx_set_sysvar_test.go
+++ b/pkg/ndau/tx_set_sysvar_test.go
@@ -49,10 +49,31 @@ func initAppSetSysvar(t *testing.T) (app *App, pvts []signature.PrivateKey) {
 func TestValidSetSysvar(t *testing.T) {
 	app, privateKeys := initAppSetSysvar(t)
 
-	ssv := NewSetSysvar("foo", []byte("bar"), 1, privateKeys...)
+	strVal := wkt.String("bar")
+	strData, err := strVal.MarshalMsg(nil)
+	require.NoError(t, err)
 
-	resp := deliverTx(t, app, ssv)
+	ssv := NewSetSysvar("foo", strData, 1, privateKeys...)
+
+	resp := deliverTxNoContext(t, app, ssv)
 	require.Equal(t, code.OK, code.ReturnCode(resp.Code))
+
+	var fooStr wkt.String
+	err = app.System("foo", &fooStr)
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(fooStr))
+
+	strVal = wkt.String("")
+	strData, err = strVal.MarshalMsg(nil)
+	require.NoError(t, err)
+
+	ssv = NewSetSysvar("foo", strData, 2, privateKeys...)
+
+	resp = deliverTxNoContext(t, app, ssv)
+	require.Equal(t, code.OK, code.ReturnCode(resp.Code))
+
+	err = app.System("foo", &fooStr)
+	require.EqualError(t, err, "Sysvar foo does not exist")
 }
 
 func TestSetSysvarIsValidWithSingleKey(t *testing.T) {

--- a/pkg/ndau/tx_set_sysvar_test.go
+++ b/pkg/ndau/tx_set_sysvar_test.go
@@ -46,6 +46,7 @@ func initAppSetSysvar(t *testing.T) (app *App, pvts []signature.PrivateKey) {
 	return
 }
 
+// set a sysvar, test for the value, unset the sysvar, and test for error
 func TestValidSetSysvar(t *testing.T) {
 	app, privateKeys := initAppSetSysvar(t)
 

--- a/pkg/ndau/tx_test_helpers.go
+++ b/pkg/ndau/tx_test_helpers.go
@@ -233,6 +233,8 @@ func deliverTx(t *testing.T, app *App, tx metatx.Transactable) abci.ResponseDeli
 	return resp
 }
 
+// delivers a transaction without saving and restoring sysvar state, which is needed to test
+// setting and unsetting of sysvar state
 func deliverTxNoContext(t *testing.T, app *App, tx metatx.Transactable) abci.ResponseDeliverTx {
 	app.BeginBlock(abci.RequestBeginBlock{
 		Header: abci.Header{


### PR DESCRIPTION
Pad voting history with good votes if a node is newly registered. Delete a sysvar by setting it to an empty string (now correctly checking for type errors).