### PR TITLE
Prevent panic when a node has no delegated accounts

### DIFF
--- a/pkg/ndau/tx_credit_eai.go
+++ b/pkg/ndau/tx_credit_eai.go
@@ -439,6 +439,12 @@ func (app *App) recalc(stateI metast.State, feature string, tx *CreditEAI) (meta
 		// rest of the CreditEAI calculation
 
 		delegatedAccounts := state.Delegates[tx.Node.String()]
+
+		// If there are no accounts delegated to the node, there's nothing to do
+		if len(delegatedAccounts) == 0 {
+			return state, nil
+		}
+
 		delegatedAccounts[tx.Node.String()] = struct{}{}
 
 		for addrS := range delegatedAccounts {

--- a/pkg/ndau/tx_record_price.go
+++ b/pkg/ndau/tx_record_price.go
@@ -36,7 +36,7 @@ func (app *App) updatePricesAndSIB(marketPrice pricecurve.Nanocent) func(stateI 
 			marketPrice = state.MarketPrice
 		}
 		sib, target, err := app.calculateCurrentSIB(state, marketPrice, -1)
-		fmt.Println("new sib:", sib, "new target price:", target, "old target price:", state.TargetPrice)
+		fmt.Println("new sib:", sib, "new Target Price:", target, "old Target Price:", state.TargetPrice)
 		if err != nil {
 			return stateI, err
 		}

--- a/pkg/ndau/tx_record_price.go
+++ b/pkg/ndau/tx_record_price.go
@@ -36,7 +36,6 @@ func (app *App) updatePricesAndSIB(marketPrice pricecurve.Nanocent) func(stateI 
 			marketPrice = state.MarketPrice
 		}
 		sib, target, err := app.calculateCurrentSIB(state, marketPrice, -1)
-		fmt.Println("new sib:", sib, "new Target Price:", target, "old Target Price:", state.TargetPrice)
 		if err != nil {
 			return stateI, err
 		}
@@ -44,7 +43,6 @@ func (app *App) updatePricesAndSIB(marketPrice pricecurve.Nanocent) func(stateI 
 		state.MarketPrice = marketPrice
 		state.TargetPrice = target
 
-		fmt.Println("new state.SIB:", state.SIB, "new state.MarketPrice:", state.MarketPrice, "new TargetPrice:", state.TargetPrice)
 		return state, err
 	}
 }
@@ -114,7 +112,6 @@ func (app *App) calculateCurrentSIB(state *backing.State, marketPrice, nav price
 		return
 	}
 
-	fmt.Println("calling VM to calculate SIB:", sibScript, uint64(targetPrice), uint64(marketPrice), uint64(fp), app.BlockTime())
 	// compute SIB
 	vm, err := BuildVMForSIB(sibScript, uint64(targetPrice), uint64(marketPrice), uint64(fp), app.BlockTime())
 	if err != nil {
@@ -135,7 +132,6 @@ func (app *App) calculateCurrentSIB(state *backing.State, marketPrice, nav price
 	}
 
 	sib = eai.Rate(top)
-	fmt.Println("Vm returned SIB value:", sib)
 	return
 }
 
@@ -154,7 +150,6 @@ func (tx *RecordPrice) Validate(appI interface{}) error {
 
 // Apply implements metatx.Transactable
 func (tx *RecordPrice) Apply(appI interface{}) error {
-	fmt.Println("setting market price", tx.MarketPrice)
 	app := appI.(*App)
 	return app.UpdateState(app.applyTxDetails(tx), app.updatePricesAndSIB(tx.MarketPrice))
 }

--- a/pkg/ndau/tx_record_price.go
+++ b/pkg/ndau/tx_record_price.go
@@ -36,6 +36,7 @@ func (app *App) updatePricesAndSIB(marketPrice pricecurve.Nanocent) func(stateI 
 			marketPrice = state.MarketPrice
 		}
 		sib, target, err := app.calculateCurrentSIB(state, marketPrice, -1)
+		fmt.Println("new sib:", sib, "new target price:", target, "old target price:", state.TargetPrice)
 		if err != nil {
 			return stateI, err
 		}
@@ -43,6 +44,7 @@ func (app *App) updatePricesAndSIB(marketPrice pricecurve.Nanocent) func(stateI 
 		state.MarketPrice = marketPrice
 		state.TargetPrice = target
 
+		fmt.Println("new state.SIB:", state.SIB, "new state.MarketPrice:", state.MarketPrice, "new TargetPrice:", state.TargetPrice)
 		return state, err
 	}
 }
@@ -112,6 +114,7 @@ func (app *App) calculateCurrentSIB(state *backing.State, marketPrice, nav price
 		return
 	}
 
+	fmt.Println("calling VM to calculate SIB:", sibScript, uint64(targetPrice), uint64(marketPrice), uint64(fp), app.BlockTime())
 	// compute SIB
 	vm, err := BuildVMForSIB(sibScript, uint64(targetPrice), uint64(marketPrice), uint64(fp), app.BlockTime())
 	if err != nil {
@@ -132,6 +135,7 @@ func (app *App) calculateCurrentSIB(state *backing.State, marketPrice, nav price
 	}
 
 	sib = eai.Rate(top)
+	fmt.Println("Vm returned SIB value:", sib)
 	return
 }
 
@@ -150,6 +154,7 @@ func (tx *RecordPrice) Validate(appI interface{}) error {
 
 // Apply implements metatx.Transactable
 func (tx *RecordPrice) Apply(appI interface{}) error {
+	fmt.Println("setting market price", tx.MarketPrice)
 	app := appI.(*App)
 	return app.UpdateState(app.applyTxDetails(tx), app.updatePricesAndSIB(tx.MarketPrice))
 }


### PR DESCRIPTION
If a node has no accounts delegated to it, it must not attempt to process the node's (empty) map of accounts.