### PR TITLE
Return an error if the ndaunode config file cannot be opened

### DIFF
--- a/pkg/api_sdk/client.go
+++ b/pkg/api_sdk/client.go
@@ -45,7 +45,7 @@ func NewClient(node string) (*Client, error) {
 	return &Client{
 		addr: u,
 		http: &http.Client{
-			Timeout: 5 * time.Second,
+			Timeout: 30 * time.Second, //Nodes have gotten slower, we need a longer timeout
 		},
 	}, nil
 }

--- a/pkg/api_sdk/client.go
+++ b/pkg/api_sdk/client.go
@@ -45,7 +45,7 @@ func NewClient(node string) (*Client, error) {
 	return &Client{
 		addr: u,
 		http: &http.Client{
-			Timeout: 30 * time.Second, //Nodes have gotten slower, we need a longer timeout
+			Timeout: 60 * time.Second, //Nodes have gotten slower, we need a longer timeout
 		},
 	}, nil
 }

--- a/pkg/ndau/config/config.go
+++ b/pkg/ndau/config/config.go
@@ -110,9 +110,16 @@ func Load(configPath string) (*Config, error) {
 // If the file does not exist, a default is transparently created
 func LoadDefault(configPath string) (*Config, error) {
 	config, err := Load(configPath)
-	if err != nil && os.IsNotExist(err) {
-		config, err = DefaultConfig()
+
+	// EJM - 2023-02-07 Failure to load the config file should be a fatal error, not a signal to enable all features
+	// all the time. If a node with all (known) features enabled is desired, just create a config file and set all
+	// feature heights to 0. Setting all features active because the config file is in the wrong place leads to
+	// errors (app hash mismatches) that are difficult to debug.
+
+	if err != nil {
+		return nil, err
 	}
+
 	return config, err
 }
 

--- a/pkg/ndau/transaction_fee.go
+++ b/pkg/ndau/transaction_fee.go
@@ -48,7 +48,7 @@ func (app *App) calculateTxFee(tx metatx.Transactable) (math.Ndau, error) {
 // exchange account. Now SIB will be imposed only if the source is not an authorized exchange account
 // and the destination is an authorized exchange account.
 
-// Addresses create with an "ndx" prefix are now always treated as exchange addresses for the purpose
+// Addresses created with an "ndx" prefix are now always treated as exchange addresses for the purpose
 // of calculating SIB, regardless of whether they're actually marked as authorized exchange addresses.
 
 func (app *App) calculateSIB(tx NTransactable) (math.Ndau, error) {
@@ -79,10 +79,18 @@ func (app *App) calculateSIB(tx NTransactable) (math.Ndau, error) {
 						if err != nil {
 							return 0, errors.Wrap(err, "determining whether tx destination is an exchange account")
 						}
+
 						// Check for exchange-format destinations that haven't been set up with CreateChildAccount yet,
 						// to prevent such addresses from avoiding SIB on incoming transfers.
-						if dest.String()[:3] == "ndx" {
-							isDestinationExchangeAccount = true
+
+						// Fix for v1.5.2 - this feature did not have a height gate specified. There were several such
+						// transfers made (nda->ndx with no SIB) before this fix, so the current image is no longer able
+						// to catch up from genesis.
+
+						if app.IsFeatureActive("ndxAreAllExchange") {
+							if dest.String()[:3] == "ndx" {
+								isDestinationExchangeAccount = true
+							}
 						}
 						if isDestinationExchangeAccount {
 							sib, err := signed.MulDiv(

--- a/pkg/ndau/tx_credit_eai.go
+++ b/pkg/ndau/tx_credit_eai.go
@@ -241,10 +241,14 @@ func (tx *CreditEAI) Apply(appI interface{}) error {
 
 					if useCurrentLockBonus {
 						currentLockBonus := lockedBonusRateTable.RateAt(acctData.Lock.NoticePeriod)
-						app.DecoratedTxLogger(tx).WithFields(log.Fields{
-							"acctLockBonus":    acctData.Lock.Bonus.String(),
-							"currentLockBonus": currentLockBonus.String(),
-						}).Info("lock bonus update")
+						/*
+							2023-05-02 Remove uninteresting logging message for EVERY locked account on EVERY CreditEAI transaction!
+
+									app.DecoratedTxLogger(tx).WithFields(log.Fields{
+									"acctLockBonus":    acctData.Lock.Bonus.String(),
+									"currentLockBonus": currentLockBonus.String(),
+								}).Info("lock bonus update")
+						*/
 						if acctData.Lock.Bonus != currentLockBonus {
 							acctData.Lock.Bonus = currentLockBonus
 							state.Accounts[addrS].Lock.Bonus = acctData.Lock.Bonus

--- a/pkg/ndauapi/reqres/respondJSON.go
+++ b/pkg/ndauapi/reqres/respondJSON.go
@@ -42,6 +42,7 @@ func RespondJSON(w http.ResponseWriter, res Responder) {
 	}
 
 	w.Header().Add("Content-Type", "application/json")
+	w.Header().Add("X-Robots-Tag", "noindex")
 	w.WriteHeader(status)  // doesn't return an error
 	_, err = w.Write(resB) // ignoring bytes written
 	if err != nil {

--- a/pkg/ndauapi/svc/logging.go
+++ b/pkg/ndauapi/svc/logging.go
@@ -51,6 +51,7 @@ func LogMW(handler http.Handler, logger logrus.FieldLogger) http.HandlerFunc {
 			"code":       lw.status,
 			"len":        lw.length,
 			"ua":         r.Header.Get("User-Agent"),
+			"client":     r.Header.Get("X-Forwarded-For"),
 			"took":       duration,
 		}).Info("REQ")
 	}


### PR DESCRIPTION
The previous behavior was that if no config.toml file was found (specifying block heights for various feature gates) there was no error and all features were reported to be active (by IsFeatureActive). This caused hard-to-debug errors if a node started from a snapshot lower than any of the height gates. Turning on features when they're not explicitly enabled is always an error. ndaunode will now terminate with a file open error if the config.toml file cannot be opened.